### PR TITLE
update srcrev to BartonCore 0.9.3

### DIFF
--- a/recipes-core/barton-core/barton_0.9.9.bb
+++ b/recipes-core/barton-core/barton_0.9.9.bb
@@ -17,7 +17,7 @@ DEPENDS_append = " \
 RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
-SRCREV = "9f80116ec91f599e30fae9b1e57c3f21c9bd234e"
+SRCREV = "baef4966c3d844da2f5073543f5c7cf8e394e69c"
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
The SRCREV was pointing to a SHA within the original private version of the BartonCore github repository. This repository was made public and all history was deleted, so this SHA was invalid.

Update the SRCREV to tag 0.9.3 in the public repository.