### PR TITLE
Add capability to extend BartonProjectConfig.in

### DIFF
--- a/recipes-matter/barton-matter/files/BartonProjectConfig.in
+++ b/recipes-matter/barton-matter/files/BartonProjectConfig.in
@@ -49,6 +49,8 @@
 #define LOCALSTATEDIR CHIP_BARTON_CONF_DIR // CHIP Counters Config
 #define CHIP_CONFIG_KVS_PATH CHIP_BARTON_CONF_DIR "/matterkv"
 
+#include "BartonProjectConfigCustom.h"
+
 // ------------------------------------
 
 #endif /* CHIPPROJECTCONFIG_H */

--- a/recipes-matter/barton-matter/files/barton.cmake
+++ b/recipes-matter/barton-matter/files/barton.cmake
@@ -34,6 +34,7 @@ function(barton_build MATTER_CONF_DIR)
     execute_process(COMMAND ${CMAKE_CURRENT_LIST_DIR}/activate.sh)
 
     configure_file(${CMAKE_CURRENT_LIST_DIR}/BartonProjectConfig.in BartonProjectConfig.h @ONLY)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/BartonProjectConfigCustom.in BartonProjectConfigCustom.h @ONLY)
 
     matter_common_gn_args(
         DEBUG       CONFIG_CHIP_DEBUG
@@ -111,6 +112,7 @@ function(barton_build MATTER_CONF_DIR)
     install(FILES ${MATTER_LIBRARIES} DESTINATION lib)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/libBartonMatter.a DESTINATION lib)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BartonProjectConfig.h DESTINATION ${MATTER_HEADER_DESTINATION})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BartonProjectConfigCustom.h DESTINATION ${MATTER_HEADER_DESTINATION})
 
     file(GLOB_RECURSE BARTON_HEADERS ${MATTER_ROOT}/third_party/barton/*.h*)
     install(FILES ${BARTON_HEADERS} DESTINATION ${MATTER_HEADER_DESTINATION})


### PR DESCRIPTION
Projects that extend the barton-matter recipe will need to be able to specify custom project configuration options, and potentially override barton-matter's defaults.  This adds a new variable "MATTER_PROJECT_CUSTOM" which a .bbappend file can set and point to a header file which will be processed by cmake's configure_file() and included at the bottom of BartonProjecConfig.h