### PR TITLE
Cleanup MATTER_CONF_DIR handling. Disable ARL.

### DIFF
--- a/recipes-matter/barton-matter/files/CMakeLists.txt
+++ b/recipes-matter/barton-matter/files/CMakeLists.txt
@@ -2,9 +2,4 @@ cmake_minimum_required(VERSION 3.19)
 project("barton-matter")
 include(barton.cmake)
 
-if(NOT MATTER_CONF_DIR)
-    message(WARNING "Using default /tmp for matter configuration.")
-    set(MATTER_CONF_DIR /tmp)
-endif()
-
 barton_build(${MATTER_CONF_DIR})

--- a/recipes-matter/barton-matter/files/barton.cmake
+++ b/recipes-matter/barton-matter/files/barton.cmake
@@ -82,7 +82,7 @@ function(barton_build MATTER_CONF_DIR)
     matter_add_gn_arg_bool("chip_system_config_use_lwip" false)
     matter_add_gn_arg_bool("chip_system_config_use_sockets" true)
     matter_add_gn_arg_bool("chip_with_lwip" false)
-    matter_add_gn_arg_bool("chip_enable_access_restrictions" true)
+    matter_add_gn_arg_bool("chip_enable_access_restrictions" false)
 
     matter_generate_args_tmp_file()
 
@@ -93,8 +93,8 @@ function(barton_build MATTER_CONF_DIR)
     set(MATTER_HEADER_DESTINATION include/matter)
 
     get_target_property(MATTER_INCLUDE_DIRECTORIES ${BARTON_MATTER_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
-    list(APPEND MATTER_INCLUDE_DIRECTORIES ${MATTER_ROOT}/third_party/barton/zzz_generated/third_party/barton/barton/zap/app-templates)
-    list(APPEND MATTER_INCLUDE_DIRECTORIES ${MATTER_ROOT}/third_party/inipp/repo/inipp)
+    list(APPEND MATTER_INCLUDE_DIRECTORIES "${MATTER_ROOT}/third_party/barton/zzz_generated/third_party/barton/barton/zap/app-templates")
+    list(APPEND MATTER_INCLUDE_DIRECTORIES "${MATTER_ROOT}/third_party/inipp/repo/inipp")
 
     foreach(MATTER_INCLUDE_DIR ${MATTER_INCLUDE_DIRECTORIES})
 


### PR DESCRIPTION
Users of barton-matter are now required to specify MATTER_CONF_DIR which is a path to where the Matter SDK stores persisten configuration files.

Also disabled Access Restriction List support since that is something a barton-matter user would set.