### PR TITLE
Enable building barton-example-app

### DIFF
--- a/recipes-core/barton-core/barton_git.bb
+++ b/recipes-core/barton-core/barton_git.bb
@@ -1,0 +1,68 @@
+DESCRIPTION = "Barton IoT Platform Library"
+HOMEPAGE = "https://github.com/rdkcentral/BartonCore"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1079582effd6f382a3fba8297d579b46"
+
+DEPENDS:append = " \
+    cjson \
+    curl \
+    dbus \
+    glib-2.0 \
+    mbedtls \
+    libxml2 \
+"
+
+RPROVIDES_${PN} += "barton"
+
+SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
+SRCREV = "e7b888d9d7e50c0236416d23dc4eb57e4062758a"
+S = "${WORKDIR}/git"
+PR = "r0"
+PV = "1.1.0+git"
+
+inherit cmake pkgconfig
+
+# These options provide a convenient facade in front of bitbake dependency management. A client
+# can choose to just overwrite EXTRA_OECMAKE options directly if they wish but must be mindful of
+# dependencies.
+BARTON_BUILD_MATTER ?= "OFF"
+BARTON_BUILD_THREAD ?= "OFF"
+BARTON_BUILD_ZIGBEE ?= "OFF"
+BARTON_GEN_GIR ?= "OFF"
+BARTON_BUILD_TESTS ?= "OFF"
+EXTRA_OECMAKE = "\
+    -DBCORE_BUILD_REFERENCE=OFF \
+    -DBCORE_GEN_GIR=${BARTON_GEN_GIR} \
+    -DBUILD_TESTING=${BARTON_BUILD_TESTS} \
+    -DBCORE_MATTER=${BARTON_BUILD_MATTER} \
+    -DBCORE_THREAD=${BARTON_BUILD_THREAD} \
+    -DBCORE_ZIGBEE=${BARTON_BUILD_ZIGBEE} \
+"
+
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_MATTER', 'ON', 'barton-matter jsoncpp', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', 'otbr-agent', '', d)}"
+RDEPENDS_${PN}:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', 'otbr-agent', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_TESTS', 'ON', 'cmocka gtest', '', d)}"
+#TODO: zigbee
+#TODO: gir generation - Barton cmake looks for the existence of g-ir tools and does the generation on its own. We do not use gobject-introspection.bbclass at this time.
+
+do_install:append() {
+    install -d ${D}${includedir}/barton
+
+    # Install public API headers
+    if [ -d ${S}/api/c/public ]; then
+        cp -r --no-preserve=ownership ${S}/api/c/public/* ${D}${includedir}/barton/
+    else
+        echo "Warning: No public API headers found in ${S}/api/c/public"
+        exit 1
+    fi
+}
+
+# Define what goes in the main runtime package
+FILES_${PN} = "${libdir}/libBartonCore.so.*"
+
+# Ensure the dev package contains the public API headers
+FILES_${PN}-dev += "${includedir}/barton/"
+
+# Skip QA check for .so files in the -dev package
+INSANE_SKIP_${PN}-dev += "dev-elf"

--- a/recipes-matter/barton-matter-example/barton-matter_1.4.0.bbappend
+++ b/recipes-matter/barton-matter-example/barton-matter_1.4.0.bbappend
@@ -13,5 +13,4 @@ MATTER_ZAP_FILE = "${WORKDIR}/barton.zap"
 MATTER_ZZZ_GENERATED = "${WORKDIR}/zzz_generated"
 
 # Set persistent storage location for production use
-EXTRA_OECMAKE:remove = "-DMATTER_CONF_DIR=/tmp"
-EXTRA_OECMAKE += "-DMATTER_CONF_DIR=/var/lib/my-product"
+MATTER_CONF_DIR = "/tmp/barton-matter-example"

--- a/recipes-support/gn/gn_git.bb
+++ b/recipes-support/gn/gn_git.bb
@@ -1,0 +1,28 @@
+SUMMARY = "GN is a meta-build system that generates build files for Ninja."
+LICENSE = "BSD-3-Clause & Unicode"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d \
+                    file://src/base/third_party/icu/LICENSE;md5=97cdee8fe9e91b393a616bc13c8081db"
+
+SRC_URI = "git://gn.googlesource.com/gn.git;protocol=https"
+
+DEPENDS = "ninja-native"
+
+SRCREV = "07e2e1b9377fec345575067078257e546affd858"
+
+S = "${WORKDIR}/git"
+PV = "1.0.0+git"
+PR = "r0"
+
+do_configure () {
+    python3 build/gen.py --no-strip --out-path ${B}
+}
+
+do_compile () {
+    ninja -C ${B}
+}
+
+do_install () {
+    install -D ${B}/gn ${D}${bindir}/gn
+}
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This commit adds gn and various tweaks to enable building barton-example-app with matter. It also adds a barton_git recipe to use an unreleased barton SHA.