### PR TITLE
Merge branch 'main' into 'develop'

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,13 @@
+name: "CLA"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLA-Lite:
+    name: "Signature"
+    uses: rdkcentral/cmf-actions/.github/workflows/cla.yml@main
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT }}


### PR DESCRIPTION
Some commits directly on main for CLA action have cause a divergence with develop. This is a one time fix, nothing should ever go direct to 'main' without going to 'develop' first from this point on.