### PR TITLE
Add Release Actions

### DIFF
--- a/.github/workflows/release-finish.yml
+++ b/.github/workflows/release-finish.yml
@@ -1,0 +1,118 @@
+name: "Finish Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_finish:
+        description: 'Type "CONFIRM" to proceed with finishing the release'
+        required: true
+        type: string
+
+jobs:
+  finish-release:
+    name: "Complete Release Process"
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Validate confirmation
+        run: |
+          if [ "${{ github.event.inputs.confirm_finish }}" != "CONFIRM" ]; then
+            echo "Error: You must type 'CONFIRM' to proceed with finishing the release"
+            exit 1
+          fi
+      
+      - name: Validate release branch
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          if [[ ! "$BRANCH_NAME" =~ ^release/.+ ]]; then
+            echo "Error: This workflow can only be run from a release branch (release/*)"
+            echo "Current branch: $BRANCH_NAME"
+            exit 1
+          fi
+          echo "✅ Running from valid release branch: $BRANCH_NAME"
+      
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      
+      - name: Install git-flow
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-flow
+      
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Fetch all branches
+        run: |
+          git fetch origin main:main
+          git fetch origin develop:develop
+          git fetch origin ${{ steps.extract_release.outputs.branch_name }}
+      
+      - name: Initialize git-flow
+        run: |
+          # Initialize git-flow with default settings
+          git config gitflow.branch.master main
+          git flow init -d
+      
+      - name: Extract release name
+        id: extract_release
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          RELEASE_NAME=${BRANCH_NAME#release/}
+          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "Extracted release name: $RELEASE_NAME"
+      
+      - name: Finish git-flow release
+        run: |
+          echo "🏁 Finishing git-flow release: ${{ steps.extract_release.outputs.release_name }}"
+          
+          # Switch to the release branch
+          git checkout ${{ steps.extract_release.outputs.branch_name }}
+          
+          # Configure git-flow to not use GPG signing for this automated process
+          git config gitflow.release.finish.sign false
+          git config gitflow.release.finish.signingkey ""
+          
+          # Finish the release - this will:
+          # 1. Merge release branch into main
+          # 2. Tag the release
+          # 3. Merge back into develop
+          # 4. Delete the release branch
+          git flow release finish -m "Release ${{ steps.extract_release.outputs.release_name }}" ${{ steps.extract_release.outputs.release_name }}
+          
+          # Push all changes and tags
+          git push origin main
+          git push origin develop
+          git push origin --tags
+          
+          echo "✅ Git-flow release finished successfully"
+          echo "✅ Release tagged as: ${{ steps.extract_release.outputs.release_name }}"
+      
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_release.outputs.release_name }}
+          release_name: Release ${{ steps.extract_release.outputs.release_name }}
+          body: |
+            Release ${{ steps.extract_release.outputs.release_name }}
+            
+            This release was created automatically using the git-flow workflow.
+            
+            ## Changes
+            This release includes all changes from the `release/${{ steps.extract_release.outputs.release_name }}` branch.
+            
+            ## Git Flow Process
+            - ✅ Release branch merged to main
+            - ✅ Release tagged as `${{ steps.extract_release.outputs.release_name }}`
+            - ✅ Tag merged back to develop
+            - ✅ Release branch cleaned up
+          draft: false
+          prerelease: false

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,0 +1,66 @@
+name: "Start Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Release name (e.g., 1.0)'
+        required: true
+        type: string
+
+jobs:
+  start-release:
+    name: "Create Release Branch"
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: develop
+      
+      - name: Install git-flow
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-flow
+      
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      
+      - name: Initialize git-flow
+        run: |
+          # Initialize git-flow with default settings
+          git flow init -d
+      
+      - name: Validate release name
+        run: |
+          RELEASE_NAME="${{ github.event.inputs.release_name }}"
+          if [[ ! "$RELEASE_NAME" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "Error: Release name contains invalid characters. Only alphanumeric, dots, hyphens, and underscores are allowed."
+            exit 1
+          fi
+          echo "Release name is valid: $RELEASE_NAME"
+      
+      - name: Check if release branch already exists
+        run: |
+          RELEASE_BRANCH="release/${{ github.event.inputs.release_name }}"
+          if git show-ref --verify --quiet refs/remotes/origin/$RELEASE_BRANCH; then
+            echo "Error: Release branch $RELEASE_BRANCH already exists"
+            exit 1
+          fi
+          echo "Release branch $RELEASE_BRANCH does not exist, proceeding..."
+      
+      - name: Start git-flow release
+        run: |
+          echo "🚀 Starting git-flow release: ${{ github.event.inputs.release_name }}"
+          git flow release start ${{ github.event.inputs.release_name }}
+          
+          # Push the release branch to remote
+          git push -u origin release/${{ github.event.inputs.release_name }}
+          
+          echo "✅ Release branch release/${{ github.event.inputs.release_name }} created successfully"
+          echo "🔗 Branch URL: ${{ github.server_url }}/${{ github.repository }}/tree/release/${{ github.event.inputs.release_name }}"


### PR DESCRIPTION
This commit adds actions to start and finish a release via the git-flow workflow. They are meant to be run manually by a maintainer. Start will generate the release branch for a release, allowing manual release prep on that branch. Finish will merge the branch to main, tag the release, merge the tag back up into develop, and then delete the release branch.