### PR TITLE
Add BartonCore 3.1.1

### DIFF
--- a/recipes-core/barton-common/barton-common_0.1.3.bb
+++ b/recipes-core/barton-common/barton-common_0.1.3.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "Barton IoT Platform Library"
+HOMEPAGE = "https://github.com/rdkcentral/BartonCommon"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1079582effd6f382a3fba8297d579b46"
+
+DEPENDS:append = " \
+    cjson \
+    curl \
+    dbus \
+    glib-2.0 \
+    mbedtls \
+    libxml2 \
+"
+
+SRC_URI = "git://git@github.com/rdkcentral/BartonCommon.git;protocol=ssh;name=barton;nobranch=1"
+SRCREV = "5cbc66ae7640dcf64a5f8a70f1000042e743099a"
+S = "${WORKDIR}/git"
+PR = "r0"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE = "\
+    -DBUILD_TESTING=OFF \
+"
+
+FILES_${PN}-dev += "${libdir}/cmake"

--- a/recipes-core/barton-common/barton-common_0.1.3.bb
+++ b/recipes-core/barton-common/barton-common_0.1.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Barton IoT Platform Library"
+DESCRIPTION = "Common libraries and utilities shared across Barton projects"
 HOMEPAGE = "https://github.com/rdkcentral/BartonCommon"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1079582effd6f382a3fba8297d579b46"

--- a/recipes-core/barton-core/barton_3.1.1.bb
+++ b/recipes-core/barton-core/barton_3.1.1.bb
@@ -1,0 +1,90 @@
+DESCRIPTION = "Barton IoT Platform Library"
+HOMEPAGE = "https://github.com/rdkcentral/BartonCore"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1079582effd6f382a3fba8297d579b46"
+
+DEPENDS:append = " \
+    cjson \
+    curl \
+    dbus \
+    glib-2.0 \
+    mbedtls \
+    libxml2 \
+    barton-common \
+"
+
+RPROVIDES:${PN} += "barton"
+
+SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
+SRCREV = "31f8d0feacb8e5ea7f9f99352967b9804c57e6d8"
+S = "${WORKDIR}/git"
+PR = "r0"
+
+inherit cmake pkgconfig python3native
+
+# These options provide a convenient facade in front of bitbake dependency management. A client
+# can choose to just overwrite EXTRA_OECMAKE options directly if they wish but must be mindful of
+# dependencies.
+BARTON_BUILD_REFERENCE ?= "OFF"
+BARTON_BUILD_MATTER ?= "OFF"
+BARTON_BUILD_THREAD ?= "OFF"
+BARTON_BUILD_ZIGBEE ?= "OFF"
+BARTON_GEN_GIR ?= "OFF"
+BARTON_BUILD_TESTS ?= "OFF"
+BARTON_VALIDATE_MATTER_SCHEMAS ?= "OFF"
+BARTON_USE_MATTERJS ?= "OFF"
+# This should be an absolute path within to the target sysroot (i.e, often /).
+# This default value matches Barton's default for BCORE_MATTER_SBMD_SPECS_DIR.
+BARTON_SBMD_SPEC_DIR ?= "${prefix}/sbmd-specs"
+
+EXTRA_OECMAKE = "\
+    -DBCORE_BUILD_REFERENCE=${BARTON_BUILD_REFERENCE} \
+    -DBCORE_GEN_GIR=${BARTON_GEN_GIR} \
+    -DBUILD_TESTING=${BARTON_BUILD_TESTS} \
+    -DBCORE_MATTER=${BARTON_BUILD_MATTER} \
+    -DBCORE_THREAD=${BARTON_BUILD_THREAD} \
+    -DBCORE_ZIGBEE=${BARTON_BUILD_ZIGBEE} \
+    -DBCORE_MATTER_VALIDATE_SCHEMAS=${BARTON_VALIDATE_MATTER_SCHEMAS} \
+    -DBCORE_MATTER_USE_MATTERJS=${BARTON_USE_MATTERJS} \
+    -DBCORE_MATTER_SBMD_SPECS_DIR=${BARTON_SBMD_SPEC_DIR} \
+    -DBCORE_BUILD_THIRD_PARTY_BARTON_COMMON=OFF \
+"
+
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', ' barton-linenoise', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_MATTER', 'ON', ' barton-matter jsoncpp yaml-cpp quickjs', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', ' otbr-agent', '', d)}"
+RDEPENDS:${PN}:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', ' otbr-agent', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_TESTS', 'ON', ' cmocka gtest', '', d)}"
+#TODO: zigbee
+#TODO: gir generation - Barton cmake looks for the existence of g-ir tools and does the generation on its own. We do not use gobject-introspection.bbclass at this time.
+
+do_install:append() {
+    install -d ${D}${includedir}/barton
+
+    # Install public API headers
+    if [ -d ${S}/api/c/public ]; then
+        cp -r --no-preserve=ownership ${S}/api/c/public/* ${D}${includedir}/barton/
+    else
+        echo "Warning: No public API headers found in ${S}/api/c/public"
+        exit 1
+    fi
+
+    # BartonCore CMake does not generate install instructions for the reference app
+    if "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', 'true', 'false', d)}"; then
+        install -d ${D}${bindir}
+        install -m 0755 ${WORKDIR}/build/reference/barton-core-reference ${D}${bindir}/barton-core-reference
+    fi
+}
+
+FILES:${PN} += "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', '${bindir}/barton-core-reference', '', d)}"
+
+FILES:${PN} += "${@bb.utils.contains('BARTON_BUILD_MATTER', 'ON', '${BARTON_SBMD_SPEC_DIR}', '', d)}"
+
+# Define what goes in the main runtime package
+FILES:${PN} += "${libdir}/libBartonCore.so.*"
+
+# Ensure the dev package contains the public API headers
+FILES:${PN}-dev += "${includedir}/barton/"
+
+# Skip QA check for .so files in the -dev package
+INSANE_SKIP:${PN}-dev += "dev-elf"

--- a/recipes-core/barton-core/barton_3.1.1.bb
+++ b/recipes-core/barton-core/barton_3.1.1.bb
@@ -33,7 +33,7 @@ BARTON_GEN_GIR ?= "OFF"
 BARTON_BUILD_TESTS ?= "OFF"
 BARTON_VALIDATE_MATTER_SCHEMAS ?= "OFF"
 BARTON_USE_MATTERJS ?= "OFF"
-# This should be an absolute path within to the target sysroot (i.e, often /).
+# This should be an absolute path within the target sysroot (i.e, often /).
 # This default value matches Barton's default for BCORE_MATTER_SBMD_SPECS_DIR.
 BARTON_SBMD_SPEC_DIR ?= "${prefix}/sbmd-specs"
 

--- a/recipes-core/barton-core/barton_3.1.1.bb
+++ b/recipes-core/barton-core/barton_3.1.1.bb
@@ -65,7 +65,7 @@ do_install:append() {
     if [ -d ${S}/api/c/public ]; then
         cp -r --no-preserve=ownership ${S}/api/c/public/* ${D}${includedir}/barton/
     else
-        echo "Warning: No public API headers found in ${S}/api/c/public"
+        echo "Error: No public API headers found in ${S}/api/c/public"
         exit 1
     fi
 

--- a/recipes-core/barton-example-app/barton-example-app_git.bb
+++ b/recipes-core/barton-example-app/barton-example-app_git.bb
@@ -28,11 +28,11 @@ DEPENDS:append = " \
 #
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
-SRCREV = "377e40a065b3817b2e6dbe4d91d2f2106b1d2b15"
+SRCREV = "31f8d0feacb8e5ea7f9f99352967b9804c57e6d8"
 S = "${WORKDIR}/git"
 PR = "r0"
 # Update BPV when SRCREV changes to latest semantic version
-BPV = "3.0.0"
+BPV = "3.1.1"
 PV = "${BPV}+git"
 
 inherit cmake pkgconfig

--- a/recipes-matter/barton-matter/barton-matter_1.4.2.bb
+++ b/recipes-matter/barton-matter/barton-matter_1.4.2.bb
@@ -35,7 +35,7 @@ SRC_URI += "file://matter_1.4/0003-Disable-pigweed-venv-generation-because-of-co
 # Always coordinate Matter and Barton version updates to maintain compatibility.
 SRCREV = "06523c22640ceb8b89f9a11ff2325a4481a178a3"
 S = "${WORKDIR}/git"
-PR="r1"
+PR="r2"
 
 inherit cmake pkgconfig python3native
 

--- a/recipes-matter/barton-matter/files/matter_1.4/BUILD.gn
+++ b/recipes-matter/barton-matter/files/matter_1.4/BUILD.gn
@@ -31,7 +31,8 @@ static_library("barton") {
     "//src/protocols",
     "//src/setup_payload",
     "${chip_root}/src/crypto",
-    "${chip_root}/third_party/jsoncpp"
+    "${chip_root}/third_party/jsoncpp",
+    "//src/lib/support/jsontlv"
   ]
 
   output_name = "libBartonMatter"

--- a/recipes-support/quickjs/files/CMakeLists.txt
+++ b/recipes-support/quickjs/files/CMakeLists.txt
@@ -1,0 +1,321 @@
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+# Read version from VERSION file
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" QUICKJS_VERSION_STRING)
+string(STRIP "${QUICKJS_VERSION_STRING}" QUICKJS_VERSION_STRING)
+
+# Convert date-based version to semantic version
+# QuickJS uses YYYY-MM-DD format, we'll convert to YYYY.MM.DD for CMake
+string(REPLACE "-" "." QUICKJS_VERSION "${QUICKJS_VERSION_STRING}")
+
+project(quickjs
+    VERSION ${QUICKJS_VERSION}
+    DESCRIPTION "QuickJS JavaScript Engine"
+    LANGUAGES C
+)
+
+# Set C standard
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Platform detection and configuration
+if(WIN32)
+    set(CONFIG_WIN32 ON)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(CONFIG_M32 ON)
+    endif()
+elseif(APPLE)
+    set(CONFIG_DARWIN ON)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(CONFIG_FREEBSD ON)
+endif()
+
+# Build options
+option(CONFIG_LTO "Enable Link Time Optimization" OFF)
+option(CONFIG_ASAN "Enable Address Sanitizer" OFF)
+option(CONFIG_MSAN "Enable Memory Sanitizer" OFF)
+option(CONFIG_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
+option(CONFIG_PROFILE "Enable profiling" OFF)
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+
+# Compiler-specific settings
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set(CONFIG_CLANG ON)
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    set(CONFIG_GCC ON)
+endif()
+
+# Core library source files
+set(QJS_LIB_SOURCES
+    quickjs.c
+    dtoa.c
+    libregexp.c
+    libunicode.c
+    cutils.c
+    quickjs-libc.c
+)
+
+# Create the library (shared or static based on BUILD_SHARED_LIBS)
+add_library(quickjs ${QJS_LIB_SOURCES})
+
+# Set library properties
+set_target_properties(quickjs PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    OUTPUT_NAME "quickjs"
+)
+
+# Preprocessor definitions
+target_compile_definitions(quickjs PRIVATE
+    _GNU_SOURCE
+    CONFIG_VERSION="${QUICKJS_VERSION_STRING}"
+)
+
+# Define JS_SHARED_LIBRARY only for shared builds
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(quickjs PRIVATE JS_SHARED_LIBRARY)
+endif()
+
+if(WIN32)
+    target_compile_definitions(quickjs PRIVATE
+        __USE_MINGW_ANSI_STDIO  # for standard snprintf behavior
+    )
+endif()
+
+# Check for closefrom support (Unix-like systems)
+if(NOT WIN32)
+    include(CheckCSourceCompiles)
+    check_c_source_compiles("
+        #include <stdlib.h>
+        #include <unistd.h>
+        int main() { closefrom(0); return 0; }
+    " HAVE_CLOSEFROM)
+
+    if(HAVE_CLOSEFROM)
+        target_compile_definitions(quickjs PRIVATE HAVE_CLOSEFROM)
+    endif()
+endif()
+
+# Compiler flags
+target_compile_options(quickjs PRIVATE
+    -fwrapv  # ensure that signed overflows behave as expected
+)
+
+if(CONFIG_CLANG OR CONFIG_GCC)
+    target_compile_options(quickjs PRIVATE
+        -Wall
+        -Wextra
+        -Wno-sign-compare
+        -Wno-missing-field-initializers
+        -Wundef
+        -Wuninitialized
+        -Wunused
+        -Wno-unused-parameter
+        -Wwrite-strings
+        -Wchar-subscripts
+        -funsigned-char
+    )
+
+    if(CONFIG_GCC)
+        target_compile_options(quickjs PRIVATE
+            -Wno-array-bounds
+            -Wno-format-truncation
+        )
+
+        # Check for newer GCC warnings
+        include(CheckCCompilerFlag)
+        check_c_compiler_flag(-Wno-infinite-recursion HAS_WNO_INFINITE_RECURSION)
+        if(HAS_WNO_INFINITE_RECURSION)
+            target_compile_options(quickjs PRIVATE -Wno-infinite-recursion)
+        endif()
+    endif()
+endif()
+
+# Architecture-specific settings
+if(CONFIG_M32)
+    target_compile_options(quickjs PRIVATE
+        -msse2
+        -mfpmath=sse  # use SSE math for correct FP rounding
+    )
+    if(NOT WIN32)
+        target_compile_options(quickjs PRIVATE -m32)
+        target_link_options(quickjs PRIVATE -m32)
+    endif()
+endif()
+
+# Build type specific flags
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(quickjs PRIVATE -O0)
+elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    target_compile_options(quickjs PRIVATE -Os)
+else()
+    target_compile_options(quickjs PRIVATE -O2)
+endif()
+
+# Link Time Optimization
+if(CONFIG_LTO)
+    set_target_properties(quickjs PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION TRUE
+    )
+endif()
+
+# Sanitizer support
+if(CONFIG_ASAN)
+    target_compile_options(quickjs PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(quickjs PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+endif()
+
+if(CONFIG_MSAN)
+    target_compile_options(quickjs PRIVATE -fsanitize=memory -fno-omit-frame-pointer)
+    target_link_options(quickjs PRIVATE -fsanitize=memory -fno-omit-frame-pointer)
+endif()
+
+if(CONFIG_UBSAN)
+    target_compile_options(quickjs PRIVATE -fsanitize=undefined -fno-omit-frame-pointer)
+    target_link_options(quickjs PRIVATE -fsanitize=undefined -fno-omit-frame-pointer)
+endif()
+
+# Profiling support
+if(CONFIG_PROFILE)
+    target_compile_options(quickjs PRIVATE -p)
+    target_link_options(quickjs PRIVATE -p)
+endif()
+
+# System libraries
+target_link_libraries(quickjs PRIVATE m)
+if(NOT WIN32)
+    target_link_libraries(quickjs PRIVATE dl pthread)
+else()
+    target_link_libraries(quickjs PRIVATE pthread)
+endif()
+
+# Export symbols for shared library
+if(NOT WIN32)
+    target_link_options(quickjs PRIVATE -rdynamic)
+endif()
+
+###############################################################################
+# Build qjs (QuickJS interpreter) and qjsc (QuickJS compiler) executables
+###############################################################################
+option(BUILD_EXECUTABLES "Build qjs and qjsc executables (disable for cross-compilation)" ON)
+
+if(BUILD_EXECUTABLES)
+    # qjsc - QuickJS compiler (built first, needed to generate repl.c)
+    add_executable(qjsc qjsc.c)
+    target_link_libraries(qjsc PRIVATE quickjs)
+    target_compile_definitions(qjsc PRIVATE CONFIG_VERSION="${QUICKJS_VERSION_STRING}")
+    set_target_properties(qjsc PROPERTIES OUTPUT_NAME "qjsc")
+
+    # Generate repl.c from repl.js using qjsc
+    set(REPL_JS "${CMAKE_CURRENT_SOURCE_DIR}/repl.js")
+    set(REPL_C "${CMAKE_CURRENT_BINARY_DIR}/repl.c")
+
+    add_custom_command(
+        OUTPUT ${REPL_C}
+        COMMAND $<TARGET_FILE:qjsc> -s -c -o ${REPL_C} -m ${REPL_JS}
+        DEPENDS qjsc ${REPL_JS}
+        COMMENT "Generating repl.c from repl.js"
+        VERBATIM
+    )
+
+    # qjs - QuickJS interpreter (needs generated repl.c)
+    add_executable(qjs qjs.c ${REPL_C})
+    target_link_libraries(qjs PRIVATE quickjs)
+    target_compile_definitions(qjs PRIVATE CONFIG_VERSION="${QUICKJS_VERSION_STRING}")
+    set_target_properties(qjs PROPERTIES OUTPUT_NAME "qjs")
+endif()
+
+# Install configuration
+include(GNUInstallDirs)
+
+set(_QUICKJS_INSTALL_TARGETS quickjs)
+if(BUILD_EXECUTABLES)
+    list(APPEND _QUICKJS_INSTALL_TARGETS qjs qjsc)
+endif()
+
+install(TARGETS ${_QUICKJS_INSTALL_TARGETS}
+    EXPORT quickjs-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES
+    quickjs.h
+    quickjs-libc.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/quickjs
+)
+
+# Create and install CMake config files
+include(CMakePackageConfigHelpers)
+
+# Generate version file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/quickjs-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Create a simple config file directly
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/quickjs-config.cmake" "
+include(CMakeFindDependencyMacro)
+
+# Find required dependencies
+find_dependency(Threads)
+
+# Include the targets file
+include(\"\${CMAKE_CURRENT_LIST_DIR}/quickjs-targets.cmake\")
+
+# Check that all required components are available
+check_required_components(quickjs)
+")
+
+# Install the targets and config files
+install(EXPORT quickjs-targets
+    FILE quickjs-targets.cmake
+    NAMESPACE quickjs::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/quickjs
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/quickjs-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/quickjs-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/quickjs
+)
+
+# Print configuration summary
+message(STATUS "QuickJS ${QUICKJS_VERSION_STRING} Configuration Summary:")
+message(STATUS "  Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Shared library: ${BUILD_SHARED_LIBS}")
+message(STATUS "  Executables: ${BUILD_EXECUTABLES}")
+message(STATUS "  LTO: ${CONFIG_LTO}")
+message(STATUS "  Address Sanitizer: ${CONFIG_ASAN}")
+message(STATUS "  Memory Sanitizer: ${CONFIG_MSAN}")
+message(STATUS "  UB Sanitizer: ${CONFIG_UBSAN}")
+message(STATUS "  Profiling: ${CONFIG_PROFILE}")
+if(CONFIG_M32)
+    message(STATUS "  32-bit build: ON")
+endif()

--- a/recipes-support/quickjs/quickjs_2025.09.13.2.bb
+++ b/recipes-support/quickjs/quickjs_2025.09.13.2.bb
@@ -3,8 +3,9 @@ DESCRIPTION = "QuickJS is a small and embeddable JavaScript engine. \
 It aims to support the latest ECMAScript specification."
 HOMEPAGE = "https://github.com/quickjs-ng/quickjs"
 
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=00d0a5fff8216c94faadd9a51b23695e"
+LICENSE = "MIT & Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=00d0a5fff8216c94faadd9a51b23695e \
+                    file://${THISDIR}/files/CMakeLists.txt;beginline=1;endline=22;md5=51713a44573743dcc1ebe5ccf2c9d037"
 
 QUICKJS_VERSION = "2025-09-13-2"
 # The extracted source directory is missing the -2 suffix. Additionally, S needs to be set to this directory.

--- a/recipes-support/quickjs/quickjs_2025.09.13.2.bb
+++ b/recipes-support/quickjs/quickjs_2025.09.13.2.bb
@@ -1,7 +1,7 @@
-SUMMARY = "QuickJS-NG - A mighty JavaScript engine"
+SUMMARY = "QuickJS - A small and embeddable JavaScript engine"
 DESCRIPTION = "QuickJS is a small and embeddable JavaScript engine. \
 It aims to support the latest ECMAScript specification."
-HOMEPAGE = "https://github.com/quickjs-ng/quickjs"
+HOMEPAGE = "https://bellard.org/quickjs/"
 
 LICENSE = "MIT & Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=00d0a5fff8216c94faadd9a51b23695e \

--- a/recipes-support/quickjs/quickjs_2025.09.13.2.bb
+++ b/recipes-support/quickjs/quickjs_2025.09.13.2.bb
@@ -1,0 +1,33 @@
+SUMMARY = "QuickJS-NG - A mighty JavaScript engine"
+DESCRIPTION = "QuickJS is a small and embeddable JavaScript engine. \
+It aims to support the latest ECMAScript specification."
+HOMEPAGE = "https://github.com/quickjs-ng/quickjs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=00d0a5fff8216c94faadd9a51b23695e"
+
+QUICKJS_VERSION = "2025-09-13-2"
+# The extracted source directory is missing the -2 suffix. Additionally, S needs to be set to this directory.
+EXTRACTED_LOCATION = "quickjs-2025-09-13"
+SRC_URI = "https://bellard.org/quickjs/quickjs-${QUICKJS_VERSION}.tar.xz \
+           file://CMakeLists.txt \
+          "
+
+SRC_URI[sha256sum] = "996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
+
+S = "${WORKDIR}/${EXTRACTED_LOCATION}"
+PR = "r0"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE = " \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_EXECUTABLES=OFF \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/CMakeLists.txt
+}
+
+FILES:${PN} += "${libdir}/libquickjs.so*"
+FILES:${PN}-dev += "${includedir}/quickjs ${libdir}/cmake/quickjs"


### PR DESCRIPTION
This commit adds a recipe for BartonCore 3.1.1, including an early version of the SBMD feature. To support BartonCore 3.1.1, this commit also adds BartonCommon 0.1.3 and a release of quickjs. Finally, a tweak to matter 1.4.2 publicly exposed symbols.

BartonCore 3.1.1 still uses matter 1.4.2.