### PR TITLE
RDKBACCL-985: Barton integration on BPI

### DIFF
--- a/recipes-matter/barton-matter/files/matter_1.4/BUILD.gn
+++ b/recipes-matter/barton-matter/files/matter_1.4/BUILD.gn
@@ -31,7 +31,8 @@ static_library("barton") {
     "//src/protocols",
     "//src/setup_payload",
     "${chip_root}/src/crypto",
-    "${chip_root}/third_party/jsoncpp"
+    "${chip_root}/third_party/jsoncpp",
+    "${chip_root}/src/lib/support/jsontlv"
   ]
 
   output_name = "libBartonMatter"


### PR DESCRIPTION
Reason for change: Addressing the barton compilation issue
Test Procedure: Test bluetooth feature and barton functionality
Risks: Low