### PR TITLE
Add BartonCore 4.0.0

### DIFF
--- a/recipes-core/barton-core/barton_4.0.0.bb
+++ b/recipes-core/barton-core/barton_4.0.0.bb
@@ -1,0 +1,90 @@
+DESCRIPTION = "Barton IoT Platform Library"
+HOMEPAGE = "https://github.com/rdkcentral/BartonCore"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1079582effd6f382a3fba8297d579b46"
+
+DEPENDS:append = " \
+    cjson \
+    curl \
+    dbus \
+    glib-2.0 \
+    mbedtls \
+    libxml2 \
+    barton-common \
+"
+
+RPROVIDES:${PN} += "barton"
+
+SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
+SRCREV = "7036fd3ff4d02cead355a983f57a0b54d9cb0bf3"
+S = "${WORKDIR}/git"
+PR = "r0"
+
+inherit cmake pkgconfig python3native
+
+# These options provide a convenient facade in front of bitbake dependency management. A client
+# can choose to just overwrite EXTRA_OECMAKE options directly if they wish but must be mindful of
+# dependencies.
+BARTON_BUILD_REFERENCE ?= "OFF"
+BARTON_BUILD_MATTER ?= "OFF"
+BARTON_BUILD_THREAD ?= "OFF"
+BARTON_BUILD_ZIGBEE ?= "OFF"
+BARTON_GEN_GIR ?= "OFF"
+BARTON_BUILD_TESTS ?= "OFF"
+BARTON_VALIDATE_MATTER_SCHEMAS ?= "OFF"
+BARTON_JS_ENGINE ?= "mquickjs"
+# This should be an absolute path within the target sysroot (i.e, often /).
+# This default value matches Barton's default for BCORE_MATTER_SBMD_SPECS_DIR.
+BARTON_SBMD_SPEC_DIR ?= "${prefix}/sbmd-specs"
+
+EXTRA_OECMAKE = "\
+    -DBCORE_BUILD_REFERENCE=${BARTON_BUILD_REFERENCE} \
+    -DBCORE_GEN_GIR=${BARTON_GEN_GIR} \
+    -DBUILD_TESTING=${BARTON_BUILD_TESTS} \
+    -DBCORE_MATTER=${BARTON_BUILD_MATTER} \
+    -DBCORE_THREAD=${BARTON_BUILD_THREAD} \
+    -DBCORE_ZIGBEE=${BARTON_BUILD_ZIGBEE} \
+    -DBCORE_MATTER_VALIDATE_SCHEMAS=${BARTON_VALIDATE_MATTER_SCHEMAS} \
+    -DBCORE_MATTER_SBMD_SPECS_DIR=${BARTON_SBMD_SPEC_DIR} \
+    -DBCORE_MATTER_SBMD_JS_ENGINE=${BARTON_JS_ENGINE} \
+    -DBCORE_BUILD_THIRD_PARTY_BARTON_COMMON=OFF \
+"
+
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', ' barton-linenoise', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_MATTER', 'ON', ' barton-matter jsoncpp yaml-cpp ${BARTON_JS_ENGINE}', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', ' otbr-agent', '', d)}"
+RDEPENDS:${PN}:append = "${@bb.utils.contains('BARTON_BUILD_THREAD', 'ON', ' otbr-agent', '', d)}"
+DEPENDS:append = "${@bb.utils.contains('BARTON_BUILD_TESTS', 'ON', ' cmocka gtest', '', d)}"
+#TODO: zigbee
+#TODO: gir generation - Barton cmake looks for the existence of g-ir tools and does the generation on its own. We do not use gobject-introspection.bbclass at this time.
+
+do_install:append() {
+    install -d ${D}${includedir}/barton
+
+    # Install public API headers
+    if [ -d ${S}/api/c/public ]; then
+        cp -r --no-preserve=ownership ${S}/api/c/public/* ${D}${includedir}/barton/
+    else
+        echo "Error: No public API headers found in ${S}/api/c/public"
+        exit 1
+    fi
+
+    # BartonCore CMake does not generate install instructions for the reference app
+    if "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', 'true', 'false', d)}"; then
+        install -d ${D}${bindir}
+        install -m 0755 ${WORKDIR}/build/reference/barton-core-reference ${D}${bindir}/barton-core-reference
+    fi
+}
+
+FILES:${PN} += "${@bb.utils.contains('BARTON_BUILD_REFERENCE', 'ON', '${bindir}/barton-core-reference', '', d)}"
+
+FILES:${PN} += "${@bb.utils.contains('BARTON_BUILD_MATTER', 'ON', '${BARTON_SBMD_SPEC_DIR}', '', d)}"
+
+# Define what goes in the main runtime package
+FILES:${PN} += "${libdir}/libBartonCore.so.*"
+
+# Ensure the dev package contains the public API headers
+FILES:${PN}-dev += "${includedir}/barton/"
+
+# Skip QA check for .so files in the -dev package
+INSANE_SKIP:${PN}-dev += "dev-elf"

--- a/recipes-core/barton-core/barton_4.0.0.bb
+++ b/recipes-core/barton-core/barton_4.0.0.bb
@@ -65,8 +65,7 @@ do_install:append() {
     if [ -d ${S}/api/c/public ]; then
         cp -r --no-preserve=ownership ${S}/api/c/public/* ${D}${includedir}/barton/
     else
-        echo "Error: No public API headers found in ${S}/api/c/public"
-        exit 1
+        bbfatal_log "Error: No public API headers found in ${S}/api/c/public"
     fi
 
     # BartonCore CMake does not generate install instructions for the reference app

--- a/recipes-core/barton-example-app/barton-example-app_git.bb
+++ b/recipes-core/barton-example-app/barton-example-app_git.bb
@@ -28,11 +28,11 @@ DEPENDS:append = " \
 #
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
-SRCREV = "31f8d0feacb8e5ea7f9f99352967b9804c57e6d8"
+SRCREV = "7036fd3ff4d02cead355a983f57a0b54d9cb0bf3"
 S = "${WORKDIR}/git"
 PR = "r0"
 # Update BPV when SRCREV changes to latest semantic version
-BPV = "3.1.1"
+BPV = "4.0.0"
 PV = "${BPV}+git"
 
 inherit cmake pkgconfig

--- a/recipes-support/mquickjs/files/0001-add-memory-usage-api.patch
+++ b/recipes-support/mquickjs/files/0001-add-memory-usage-api.patch
@@ -1,0 +1,99 @@
+From fd8d653d17d3c5cdb3e3f4203e9c3d64a2b6a8d2 Mon Sep 17 00:00:00 2001
+From: tlea <tlea@comcast.com>
+Date: Fri, 20 Mar 2026 10:46:29 -0500
+Subject: [PATCH] Add JS_GetMemoryUsage API for memory instrumentation
+
+---
+ mquickjs.c | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
+ mquickjs.h | 17 +++++++++++++++++
+ 2 files changed, 66 insertions(+)
+
+diff --git a/mquickjs.c b/mquickjs.c
+index a950f3c..4d537e1 100644
+--- a/mquickjs.c
++++ b/mquickjs.c
+@@ -7123,6 +7123,55 @@ static __maybe_unused void JS_DumpUniqueStrings(JSContext *ctx)
+ }
+ #endif
+ 
++int JS_GetMemoryUsage(JSContext *ctx, JSMemoryUsage *usage, int flags)
++{
++    uint8_t *ptr;
++
++    if (!ctx || !usage)
++        return -1;
++
++    usage->arena_size = ctx->stack_top - (uint8_t *)ctx;
++    usage->overhead = ctx->heap_base - (uint8_t *)ctx;
++    usage->heap_used = ctx->heap_free - ctx->heap_base;
++    usage->stack_used = ctx->stack_top - (uint8_t *)ctx->sp;
++
++    if (ctx->heap_free >= (uint8_t *)ctx->sp) {
++        usage->free_size = 0;
++    } else {
++        usage->free_size = (size_t)((uint8_t *)ctx->sp - ctx->heap_free);
++    }
++
++    /* Walk the heap to find free blocks (freed by GC but not compacted) */
++    usage->heap_free_blocks = 0;
++    usage->flags = flags;
++    if (flags & JS_MEMUSAGE_WALK_HEAP) {
++        ptr = ctx->heap_base;
++
++        while (ptr < ctx->heap_free) {
++            JSMemBlockHeader *header = (JSMemBlockHeader *)ptr;
++            int size = get_mblock_size(ptr);
++
++            if (size <= 0) {
++                break;
++            }
++
++            uint8_t *next = ptr + size;
++
++            if (next > ctx->heap_free) {
++                break;
++            }
++
++            if (header->mtag == JS_MTAG_FREE) {
++                usage->heap_free_blocks += size;
++            }
++
++            ptr = next;
++        }
++    }
++
++    return 0;
++}
++
+ void JS_DumpValueF(JSContext *ctx, const char *str,
+                    JSValue val, int flags)
+ {
+diff --git a/mquickjs.h b/mquickjs.h
+index a1557fe..ff50886 100644
+--- a/mquickjs.h
++++ b/mquickjs.h
+@@ -379,4 +379,21 @@ void JS_DumpValue(JSContext *ctx, const char *str,
+                   JSValue val);
+ void JS_DumpMemory(JSContext *ctx, JS_BOOL is_long);
+ 
++/* Flags for JS_GetMemoryUsage */
++#define JS_MEMUSAGE_WALK_HEAP  (1 << 0) /* walk heap to count free blocks (expensive) */
++
++/* Memory usage statistics */
++typedef struct JSMemoryUsage {
++    size_t arena_size;       /* total memory arena (mem_size passed to JS_NewContext) */
++    size_t heap_used;        /* heap bytes in use (includes free blocks from GC) */
++    size_t heap_free_blocks; /* bytes in freed/compacted blocks within the heap (only if JS_MEMUSAGE_WALK_HEAP) */
++    size_t stack_used;       /* stack bytes currently in use */
++    size_t free_size;        /* free gap between heap top and stack bottom */
++    size_t overhead;         /* context struct overhead (before heap_base) */
++    int flags;               /* flags passed to JS_GetMemoryUsage */
++} JSMemoryUsage;
++
++/* Get current memory usage statistics. Returns 0 on success, -1 on error. */
++int JS_GetMemoryUsage(JSContext *ctx, JSMemoryUsage *usage, int flags);
++
+ #endif /* MQUICKJS_H */
+-- 
+2.51.0
+

--- a/recipes-support/mquickjs/files/CMakeLists.txt
+++ b/recipes-support/mquickjs/files/CMakeLists.txt
@@ -1,0 +1,240 @@
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+project(mquickjs
+    VERSION 0.0.1
+    DESCRIPTION "Micro QuickJS Javascript Engine"
+    LANGUAGES C
+)
+
+# Set C standard
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+include(GNUInstallDirs)
+
+option(BUILD_EXECUTABLES "Build the mqjs interpreter" ON)
+
+###############################################################################
+# Stage 1: Build host tools to generate stdlib headers
+#
+# mquickjs requires a two-stage build:
+#   1. Compile mqjs_stdlib (host tool) from mqjs_stdlib.c + mquickjs_build.c
+#   2. Run mqjs_stdlib to generate mquickjs_atom.h and mqjs_stdlib.h
+# These generated headers are needed to compile the actual library.
+#
+# When cross-compiling, the headers must be pre-generated and placed in the
+# binary directory before cmake runs.
+###############################################################################
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_atom.h" AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/mqjs_stdlib.h")
+    message(STATUS "Using pre-generated headers (cross-compilation)")
+    # Copy pre-generated headers into the build directory where the rest of the
+    # build expects them
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_atom.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/mquickjs_atom.h" COPYONLY)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/mqjs_stdlib.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/mqjs_stdlib.h" COPYONLY)
+else()
+    # Build the stdlib generator tool (always built for the host)
+    add_executable(mqjs_stdlib_gen
+        ${CMAKE_CURRENT_SOURCE_DIR}/mqjs_stdlib.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_build.c
+    )
+    target_compile_definitions(mqjs_stdlib_gen PRIVATE _GNU_SOURCE)
+    target_compile_options(mqjs_stdlib_gen PRIVATE -O2 -fno-math-errno -fno-trapping-math)
+
+    # Generate mquickjs_atom.h by running: ./mqjs_stdlib_gen -a > mquickjs_atom.h
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mquickjs_atom.h
+        COMMAND $<TARGET_FILE:mqjs_stdlib_gen> -a > ${CMAKE_CURRENT_BINARY_DIR}/mquickjs_atom.h
+        DEPENDS mqjs_stdlib_gen
+        COMMENT "Generating mquickjs_atom.h"
+        VERBATIM
+    )
+
+    # Generate mqjs_stdlib.h by running: ./mqjs_stdlib_gen > mqjs_stdlib.h
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mqjs_stdlib.h
+        COMMAND $<TARGET_FILE:mqjs_stdlib_gen> > ${CMAKE_CURRENT_BINARY_DIR}/mqjs_stdlib.h
+        DEPENDS mqjs_stdlib_gen
+        COMMENT "Generating mqjs_stdlib.h"
+        VERBATIM
+    )
+endif()
+
+# Custom target so we can depend on the generated headers
+add_custom_target(mquickjs_generated_headers
+    DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/mquickjs_atom.h
+        ${CMAKE_CURRENT_BINARY_DIR}/mqjs_stdlib.h
+)
+
+###############################################################################
+# Stage 2: Build the mquickjs library
+###############################################################################
+
+set(MQUICKJS_LIB_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/dtoa.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libm.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cutils.c
+)
+
+add_library(mquickjs ${MQUICKJS_LIB_SOURCES})
+add_dependencies(mquickjs mquickjs_generated_headers)
+
+set_target_properties(mquickjs PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+# The generated mquickjs_atom.h must be found when compiling mquickjs.c
+target_include_directories(mquickjs
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}  # for mquickjs_atom.h
+        ${CMAKE_CURRENT_SOURCE_DIR}  # for source-local headers
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mquickjs>
+)
+
+target_compile_definitions(mquickjs PRIVATE
+    _GNU_SOURCE
+)
+
+target_compile_options(mquickjs PRIVATE
+    -Os
+    -fno-math-errno
+    -fno-trapping-math
+    -fwrapv
+    -Wall
+    -Wno-unused-parameter
+)
+
+target_link_libraries(mquickjs PUBLIC m)
+
+###############################################################################
+# Stage 3: Optionally build the mqjs interpreter
+###############################################################################
+
+if(BUILD_EXECUTABLES)
+    add_executable(mqjs
+        ${CMAKE_CURRENT_SOURCE_DIR}/mqjs.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/readline.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/readline_tty.c
+    )
+    add_dependencies(mqjs mquickjs_generated_headers)
+
+    target_include_directories(mqjs PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}   # for mqjs_stdlib.h
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    target_compile_definitions(mqjs PRIVATE _GNU_SOURCE)
+    target_compile_options(mqjs PRIVATE -O2 -fno-math-errno -fno-trapping-math)
+    target_link_libraries(mqjs PRIVATE mquickjs)
+endif()
+
+###############################################################################
+# Install configuration
+###############################################################################
+
+set(_INSTALL_TARGETS mquickjs)
+if(BUILD_EXECUTABLES)
+    list(APPEND _INSTALL_TARGETS mqjs)
+endif()
+
+install(TARGETS ${_INSTALL_TARGETS}
+    EXPORT mquickjs-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Install public headers
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_build.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_opcode.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_priv.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/cutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/dtoa.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libm.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mquickjs
+)
+
+# Also install the generated headers (needed at build time by consumers)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/mquickjs_atom.h
+    ${CMAKE_CURRENT_BINARY_DIR}/mqjs_stdlib.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mquickjs
+)
+
+# Install the stdlib source files needed by consumers to build their own stdlib
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mqjs_stdlib.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/mquickjs_build.c
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/mquickjs
+)
+
+# Create and install CMake config files
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/mquickjs-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mquickjs-config.cmake" "
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include(\"\${CMAKE_CURRENT_LIST_DIR}/mquickjs-targets.cmake\")
+check_required_components(mquickjs)
+")
+
+install(EXPORT mquickjs-targets
+    FILE mquickjs-targets.cmake
+    NAMESPACE mquickjs::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mquickjs
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/mquickjs-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/mquickjs-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mquickjs
+)
+
+message(STATUS "mquickjs Configuration Summary:")
+message(STATUS "  Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Install prefix: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "  Build shared libs: ${BUILD_SHARED_LIBS}")
+message(STATUS "  Build executables: ${BUILD_EXECUTABLES}")

--- a/recipes-support/mquickjs/mquickjs_git.bb
+++ b/recipes-support/mquickjs/mquickjs_git.bb
@@ -1,0 +1,57 @@
+SUMMARY = "mquickjs - Micro QuickJS Javascript Engine"
+DESCRIPTION = "mquickjs is a small and embeddable JavaScript engine. \
+It is a lightweight variant of QuickJS designed for resource-constrained environments."
+HOMEPAGE = "https://github.com/bellard/mquickjs"
+
+LICENSE = "MIT & Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3627525a00366841dd562ffab1470446 \
+                    file://${THISDIR}/files/CMakeLists.txt;beginline=1;endline=22;md5=51713a44573743dcc1ebe5ccf2c9d037"
+
+SRCREV = "ee50431eac9b14b99f722b537ec4cac0c8dd75ab"
+SRC_URI = "git://github.com/bellard/mquickjs.git;protocol=https;branch=main \
+           file://CMakeLists.txt \
+           file://0001-add-memory-usage-api.patch \
+          "
+
+S = "${WORKDIR}/git"
+PV = "0.0.1+git${SRCPV}"
+PR = "r0"
+
+inherit cmake pkgconfig siteinfo
+
+EXTRA_OECMAKE = " \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_EXECUTABLES=OFF \
+"
+
+# Native builds need the mqjs interpreter and can run the generator natively
+EXTRA_OECMAKE:class-native = " \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_EXECUTABLES=ON \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/CMakeLists.txt
+}
+
+# Cross-builds need pre-generated headers since the generator can't run on the host.
+# Native builds skip this — cmake builds and runs the generator natively.
+# The generator defaults to host pointer size; pass -m32 or -m64 to match the
+# target so the generated js_stdlib_table uses the correct word width.
+do_configure:prepend:class-target() {
+    ${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS} -D_GNU_SOURCE -O2 \
+        ${S}/mqjs_stdlib.c ${S}/mquickjs_build.c -lm \
+        -o ${WORKDIR}/mqjs_stdlib_gen_host
+    if [ "${SITEINFO_BITS}" = "32" ]; then
+        mqjs_gen_arch="-m32"
+    else
+        mqjs_gen_arch="-m64"
+    fi
+    ${WORKDIR}/mqjs_stdlib_gen_host $mqjs_gen_arch -a > ${S}/mquickjs_atom.h
+    ${WORKDIR}/mqjs_stdlib_gen_host $mqjs_gen_arch > ${S}/mqjs_stdlib.h
+}
+
+FILES:${PN} += "${libdir}/libmquickjs.so*"
+FILES:${PN}-dev += "${includedir}/mquickjs ${libdir}/cmake/mquickjs ${datadir}/mquickjs"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This commit adds a recipe for BartonCore 4.0.0, including improvements to SBMD and a switch from quickjs to mquickjs as the default js engine runtime. This is a significant performance improvemnt.

BartonCore 4.0.0 still uses matter 1.4.2.