### PR TITLE
RDKBACCL-2063: Build rdk-generic-broadband-image for wrynose

### DIFF
--- a/recipes-core/barton-common/barton-common_0.1.1.bb
+++ b/recipes-core/barton-common/barton-common_0.1.1.bb
@@ -14,7 +14,6 @@ DEPENDS:append = " \
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCommon.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "aadf6f2b18991deb9bd261adb8125e3caa4abfcd"
-S = "${WORKDIR}/git"
 PR = "r0"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-common/barton-common_0.1.3.bb
+++ b/recipes-core/barton-common/barton-common_0.1.3.bb
@@ -14,7 +14,6 @@ DEPENDS:append = " \
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCommon.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "5cbc66ae7640dcf64a5f8a70f1000042e743099a"
-S = "${WORKDIR}/git"
 PR = "r0"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_1.1.0.bb
+++ b/recipes-core/barton-core/barton_1.1.0.bb
@@ -16,7 +16,6 @@ RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "908d8ab4625a4377918dc44e23e9402452ffa0bc"
-S = "${WORKDIR}/git"
 PR = "r3"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_2.0.0.bb
+++ b/recipes-core/barton-core/barton_2.0.0.bb
@@ -16,7 +16,6 @@ RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "bdb58a588a370f202bcffb24664323576133f57e"
-S = "${WORKDIR}/git"
 PR = "r2"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_2.1.0.bb
+++ b/recipes-core/barton-core/barton_2.1.0.bb
@@ -16,7 +16,6 @@ RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "26554fabb1a3d7db3c258dfee20507587d56f118"
-S = "${WORKDIR}/git"
 PR = "r1"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_2.2.0.bb
+++ b/recipes-core/barton-core/barton_2.2.0.bb
@@ -16,7 +16,6 @@ RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "7e915762dafc1fe3c7e0e4120890a8359d8936fe"
-S = "${WORKDIR}/git"
 PR = "r0"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_3.0.0.bb
+++ b/recipes-core/barton-core/barton_3.0.0.bb
@@ -17,7 +17,6 @@ RPROVIDES_${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "377e40a065b3817b2e6dbe4d91d2f2106b1d2b15"
-S = "${WORKDIR}/git"
 PR = "r0"
 
 inherit cmake pkgconfig

--- a/recipes-core/barton-core/barton_3.1.1.bb
+++ b/recipes-core/barton-core/barton_3.1.1.bb
@@ -17,7 +17,6 @@ RPROVIDES:${PN} += "barton"
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "31f8d0feacb8e5ea7f9f99352967b9804c57e6d8"
-S = "${WORKDIR}/git"
 PR = "r0"
 
 inherit cmake pkgconfig python3native

--- a/recipes-core/barton-example-app/barton-example-app_git.bb
+++ b/recipes-core/barton-example-app/barton-example-app_git.bb
@@ -29,7 +29,6 @@ DEPENDS:append = " \
 
 SRC_URI = "git://git@github.com/rdkcentral/BartonCore.git;protocol=ssh;name=barton;nobranch=1"
 SRCREV = "31f8d0feacb8e5ea7f9f99352967b9804c57e6d8"
-S = "${WORKDIR}/git"
 PR = "r0"
 # Update BPV when SRCREV changes to latest semantic version
 BPV = "3.1.1"

--- a/recipes-matter/barton-matter/barton-matter_1.4.0.bb
+++ b/recipes-matter/barton-matter/barton-matter_1.4.0.bb
@@ -29,7 +29,6 @@ SRC_URI += "file://matter_1.4/0001-Fix-GetPrimary802154MACAddress-on-Linux-platf
 #  - Updating Barton may require a corresponding Matter SDK version change
 # Always coordinate Matter and Barton version updates to maintain compatibility.
 SRCREV = "43aa98c2d30ee547c6b587b9de7bbb794f175ece"
-S = "${WORKDIR}/git"
 PR="r2"
 
 inherit cmake pkgconfig

--- a/recipes-matter/barton-matter/barton-matter_1.4.2.bb
+++ b/recipes-matter/barton-matter/barton-matter_1.4.2.bb
@@ -34,7 +34,6 @@ SRC_URI += "file://matter_1.4/0003-Disable-pigweed-venv-generation-because-of-co
 #  - Updating Barton may require a corresponding Matter SDK version change
 # Always coordinate Matter and Barton version updates to maintain compatibility.
 SRCREV = "06523c22640ceb8b89f9a11ff2325a4481a178a3"
-S = "${WORKDIR}/git"
 PR="r2"
 
 inherit cmake pkgconfig python3native

--- a/recipes-matter/barton-matter/barton-matter_1.5.0.1.bb
+++ b/recipes-matter/barton-matter/barton-matter_1.5.0.1.bb
@@ -31,7 +31,6 @@ SRC_URI = "git://github.com/project-chip/connectedhomeip.git;protocol=https;bran
 SETUPTOOLS_UPGRADE_PATCH = "file://0009-pigweed-upgrade-setuptools-for-yocto.patch;patchdir=third_party/pigweed/repo"
 SRC_URI:append = "${@' ${SETUPTOOLS_UPGRADE_PATCH}' if d.getVar('DISTRO_VERSION') and bb.utils.vercmp_string(d.getVar('DISTRO_VERSION'), '5.0') < 0 else ''}"
 
-S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 PR = "r0"
 

--- a/recipes-matter/barton-matter/files/matter_1.4/0001-Fix-reading-ExtendedAddress-from-otbr-agent-39723.patch
+++ b/recipes-matter/barton-matter/files/matter_1.4/0001-Fix-reading-ExtendedAddress-from-otbr-agent-39723.patch
@@ -1,5 +1,6 @@
 From ce5a03629730e03515a083417cabccb3d7a977fa Mon Sep 17 00:00:00 2001
 From: Thomas Lea <thomas_lea@comcast.com>
+Upstream-Status: Pending
 Date: Tue, 8 Jul 2025 11:43:46 -0500
 Subject: [PATCH 1/3] Fix reading ExtendedAddress from otbr-agent (#39723)
 

--- a/recipes-matter/barton-matter/files/matter_1.4/0002-Patch-out-visibility-restriction.patch
+++ b/recipes-matter/barton-matter/files/matter_1.4/0002-Patch-out-visibility-restriction.patch
@@ -1,5 +1,6 @@
 From eec689878ff7fba49db945b614dc651511cce3e6 Mon Sep 17 00:00:00 2001
 From: Christian Leithner <christian_leithner@comcast.com>
+Upstream-Status: Pending
 Date: Mon, 15 Sep 2025 20:00:33 +0000
 Subject: [PATCH 2/3] Patch out visibility restriction
 

--- a/recipes-matter/barton-matter/files/matter_1.4/0003-Disable-pigweed-venv-generation-because-of-codegen.patch
+++ b/recipes-matter/barton-matter/files/matter_1.4/0003-Disable-pigweed-venv-generation-because-of-codegen.patch
@@ -1,5 +1,6 @@
 From 15bfa482ceba08887dead6061fa098090c57119e Mon Sep 17 00:00:00 2001
 From: Christian Leithner <christian_leithner@comcast.com>
+Upstream-Status: Pending
 Date: Thu, 23 Oct 2025 19:34:01 +0000
 Subject: [PATCH 3/3] Disable pigweed venv generation because of codegen
 

--- a/recipes-support/gn/gn_git.bb
+++ b/recipes-support/gn/gn_git.bb
@@ -9,7 +9,6 @@ DEPENDS = "ninja-native"
 
 SRCREV = "07e2e1b9377fec345575067078257e546affd858"
 
-S = "${WORKDIR}/git"
 PV = "1.0.0+git"
 PR = "r0"
 

--- a/recipes-support/linenoise/barton-linenoise_git.bb
+++ b/recipes-support/linenoise/barton-linenoise_git.bb
@@ -19,7 +19,6 @@ PV = "1.0.0+git"
 
 SRC_URI += "file://0001-Add-history-print-and-CMake-build.patch"
 
-S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 

--- a/recipes-support/linenoise/files/0001-Add-history-print-and-CMake-build.patch
+++ b/recipes-support/linenoise/files/0001-Add-history-print-and-CMake-build.patch
@@ -1,5 +1,6 @@
 From 965f31750ed1d66482a0e3e533fd73ddbfc854f8 Mon Sep 17 00:00:00 2001
 From: Thomas Lea <thomas_lea@comcast.com>
+Upstream-Status: Pending
 Date: Mon, 4 Nov 2024 16:01:34 -0600
 Source: Comcast
 Subject: [PATCH] Add history print and CMake build

--- a/recipes-support/quickjs/quickjs_2025.09.13.2.bb
+++ b/recipes-support/quickjs/quickjs_2025.09.13.2.bb
@@ -16,7 +16,7 @@ SRC_URI = "https://bellard.org/quickjs/quickjs-${QUICKJS_VERSION}.tar.xz \
 
 SRC_URI[sha256sum] = "996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
 
-S = "${WORKDIR}/${EXTRACTED_LOCATION}"
+S = "${UNPACKDIR}/${EXTRACTED_LOCATION}"
 PR = "r0"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
Reason for change: Addressing initial build issues in gateway image build. Replace WORKDIR with UNPACKDIR and add Upstream-Status in the barton-matter and linenoise patches
Test Procedure: bitbake rdk-generic-broadband-image and the dependent packages 
Risk : None